### PR TITLE
Respect database connection's table prefix when executing raw statements

### DIFF
--- a/src/Console/Admin1Code.php
+++ b/src/Console/Admin1Code.php
@@ -156,10 +156,11 @@ class Admin1Code extends Command {
      */
     protected function insertWithLoadDataInfile( $localFilePath ) {
         Schema::dropIfExists( self::TABLE_WORKING );
-        DB::statement( 'CREATE TABLE ' . self::TABLE_WORKING . ' LIKE ' . self::TABLE . ';' );
+        $prefix = DB::getTablePrefix();
+        DB::statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . ';' );
 
         $query = "LOAD DATA LOCAL INFILE '" . $localFilePath . "'
-    INTO TABLE " . self::TABLE_WORKING . "
+    INTO TABLE " . $prefix . self::TABLE_WORKING . "
           ( geonameid,
             country_code,
             admin1_code,

--- a/src/Console/AlternateName.php
+++ b/src/Console/AlternateName.php
@@ -205,7 +205,8 @@ class AlternateName extends Command {
 
     protected function initTable() {
         Schema::dropIfExists( self::TABLE_WORKING );
-        DB::statement( 'CREATE TABLE ' . self::TABLE_WORKING . ' LIKE ' . self::TABLE . ';' );
+        $prefix = DB::getTablePrefix();
+        DB::statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . ';' );
         $this->disableKeys( self::TABLE_WORKING );
     }
 
@@ -231,10 +232,11 @@ class AlternateName extends Command {
             throw $exception;
         }
 
+        $prefix = DB::getTablePrefix();
         foreach ( $localFileSplitPaths as $i => $localFileSplitPath ):
             $query = "LOAD DATA LOCAL INFILE '" . $localFileSplitPath . "'
             
-                        INTO TABLE " . self::TABLE_WORKING . "
+                        INTO TABLE " . $prefix . self::TABLE_WORKING . "
                             (   alternateNameId, 
                                 geonameid,
                                 isolanguage, 
@@ -330,9 +332,10 @@ class AlternateName extends Command {
 
         $this->comment( "Running LOAD DATA INFILE." );
 
+        $prefix = DB::getTablePrefix();
         $query = "LOAD DATA LOCAL INFILE '" . $pathToRecreatedFile . "'
             
-                        INTO TABLE " . self::TABLE_WORKING . "
+                        INTO TABLE " . $prefix . self::TABLE_WORKING . "
                             (   alternateNameId, 
                                 geonameid,
                                 isolanguage, 

--- a/src/Console/FeatureCode.php
+++ b/src/Console/FeatureCode.php
@@ -99,8 +99,9 @@ class FeatureCode extends Command {
 
         // Run each of those files through LOAD DATA INFILE.
         Schema::connection( $this->connectionName )->dropIfExists( self::TABLE_WORKING );
+        $prefix = DB::getTablePrefix();
         DB::connection( $this->connectionName )
-          ->statement( 'CREATE TABLE ' . self::TABLE_WORKING . ' LIKE ' . self::TABLE . ';' );
+            ->statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . ';' );
 
         // Now that we have all of the feature code files stored locally, we need to prepare
         // the data to be inserted into our database. Convert each tab delimited row into a php
@@ -213,12 +214,12 @@ class FeatureCode extends Command {
         list( $feature_class, $feature_code ) = explode( '.', $id );
 
         return [ 'language_code' => $language_code,
-                 'feature_class' => $feature_class,
-                 'feature_code'  => $feature_code,
-                 'name'          => $name,
-                 'description'   => $description,
-                 'created_at'    => Carbon::now(),
-                 'updated_at'    => Carbon::now(),
+            'feature_class' => $feature_class,
+            'feature_code'  => $feature_code,
+            'name'          => $name,
+            'description'   => $description,
+            'created_at'    => Carbon::now(),
+            'updated_at'    => Carbon::now(),
         ];
     }
 
@@ -269,7 +270,7 @@ class FeatureCode extends Command {
         foreach ( $validRows as $rowNumber => $row ) {
 
             $insertResult = DB::connection( $this->connectionName )->table( self::TABLE_WORKING )
-                              ->insert( $this->makeRowInsertable( $row ) );
+                ->insert( $this->makeRowInsertable( $row ) );
 
             if ( $insertResult === TRUE ) {
                 $numRowsInserted++;

--- a/src/Console/GeonamesConsoleTrait.php
+++ b/src/Console/GeonamesConsoleTrait.php
@@ -274,13 +274,15 @@ trait GeonamesConsoleTrait {
     }
 
     protected function disableKeys( string $table ): bool {
-        $query = 'ALTER TABLE ' . $table . ' DISABLE KEYS;';
+        $prefix = DB::getTablePrefix();
+        $query = 'ALTER TABLE ' . $prefix . $table . ' DISABLE KEYS;';
 
         return DB::connection( $this->connectionName )->getpdo()->exec( $query );
     }
 
     protected function enableKeys( string $table ): bool {
-        $query = 'ALTER TABLE ' . $table . ' ENABLE KEYS;';
+        $prefix = DB::getTablePrefix();
+        $query = 'ALTER TABLE ' . $prefix . $table . ' ENABLE KEYS;';
 
         return DB::connection( $this->connectionName )->getpdo()->exec( $query );
     }

--- a/src/Console/InsertGeonames.php
+++ b/src/Console/InsertGeonames.php
@@ -313,14 +313,15 @@ class InsertGeonames extends Command {
         Schema::dropIfExists( self::TABLE_WORKING );
 
         $this->line( "Creating the temp table named " . self::TABLE_WORKING );
-        DB::statement( 'CREATE TABLE ' . self::TABLE_WORKING . ' LIKE ' . self::TABLE . '; ' );
+        $prefix = DB::getTablePrefix();
+        DB::statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . '; ' );
 
 
         $this->disableKeys( self::TABLE_WORKING );
 
-
+        $localFilePath = str_replace('\\', '\\\\', $localFilePath);
         $query = "LOAD DATA LOCAL INFILE '" . $localFilePath . "'
-    INTO TABLE " . self::TABLE_WORKING . "
+    INTO TABLE " . $prefix . self::TABLE_WORKING . "
         (geonameid, 
              name, 
              asciiname, 

--- a/src/Console/IsoLanguageCode.php
+++ b/src/Console/IsoLanguageCode.php
@@ -115,12 +115,15 @@ class IsoLanguageCode extends Command {
         $this->line( "Inserting via LOAD DATA INFILE: " . $localFilePath );
 
         Schema::dropIfExists( self::TABLE_WORKING );
-        DB::statement( 'CREATE TABLE ' . self::TABLE_WORKING . ' LIKE ' . self::TABLE . ';' );
+        $prefix = DB::getTablePrefix();
+        DB::statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . ';' );
         $this->disableKeys( self::TABLE_WORKING );
 
+
         // This file includes a header row. That is why I skip the first line with the IGNORE 1 LINES statement.
+        $localFilePath = str_replace('\\', '\\\\', $localFilePath);
         $query = "LOAD DATA LOCAL INFILE '" . $localFilePath . "'
-    INTO TABLE " . self::TABLE_WORKING . " IGNORE 1 LINES
+    INTO TABLE " . $prefix . self::TABLE_WORKING . " IGNORE 1 LINES
         (   iso_639_3, 
             iso_639_2,
             iso_639_1, 

--- a/src/Console/Test.php
+++ b/src/Console/Test.php
@@ -71,7 +71,8 @@ class Test extends Command {
         Schema::dropIfExists( self::TABLE_WORKING );
 
 
-        DB::statement( 'CREATE TABLE ' . self::TABLE_WORKING . ' LIKE ' . self::TABLE . ';' );
+        $prefix = DB::getTablePrefix();
+        DB::statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . ';' );
         $this->disableKeys( self::TABLE_WORKING );
 
         $this->enableKeys( self::TABLE_WORKING );
@@ -91,7 +92,7 @@ class Test extends Command {
 
 
             $query = "LOAD DATA LOCAL INFILE '" . $filePath . "'
-    INTO TABLE " . self::TABLE_WORKING . "
+    INTO TABLE " . $prefix . self::TABLE_WORKING . "
         (   alternateNameId, 
             geonameid,
             isolanguage, 


### PR DESCRIPTION
Updated commands which includes execution of raw statements to respect the database connection's table prefix.

* Got the connection table prefix:
`$prefix = DB::connection( $this->connectionName )->getTablePrefix();`
* Then use it in raw statements:
`DB::connection( $this->connectionName )->statement( 'CREATE TABLE ' . $prefix . self::TABLE_WORKING . ' LIKE ' . $prefix . self::TABLE . ';' );`

