### PR TITLE
Pass geonames:geoname connection to all commands

### DIFF
--- a/src/Console/Geoname.php
+++ b/src/Console/Geoname.php
@@ -52,7 +52,7 @@ class Geoname extends AbstractCommand {
                            '--connection' => $this->connectionName ] );
         else:
             $this->comment( "Running the geonames:geoname artisan command in live mode." );
-            $this->call( 'geonames:download-geonames', [] );
+            $this->call( 'geonames:download-geonames', [ '--connection' => $this->connectionName ] );
             $this->call( 'geonames:insert-geonames', [ '--connection' => $this->connectionName ] );
         endif;
 


### PR DESCRIPTION
`geonames:geoname` isn't passing the connection to `geonames:download-geonames` when not running in test mode.

Fixes #38 